### PR TITLE
fix(debian): correct package name

### DIFF
--- a/packages/docker-pussh/output/DEBIAN/control
+++ b/packages/docker-pussh/output/DEBIAN/control
@@ -1,9 +1,9 @@
-Source: docker-ppush
+Source: docker-pussh
 Section: utils
 Priority: optional
 Maintainer: Dario Griffo <dariogriffo@gmail.com>
 Homepage: https://github.com/psviderski/unregistry
-Package: docker-ppush
+Package: docker-pussh
 Version: unregistry_VERSION-BUILD_VERSION+DIST
 Architecture: amd64
 Depends: 


### PR DESCRIPTION
Hi,

The package name seems wrong here, it can be seen from the repo directly: https://debian.griffo.io/apt/dists/bookworm/main/binary-amd64/Packages